### PR TITLE
Fix/vb image links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ See guide [here](docs/conference/conference.md) for workshop at a conference.
 
 ![](docs/workshop.png)
 
-Download the VirtualBox image [here](https://www.dropbox.com/sh/d82fy5aqdshiqws/AADph3wt7jsyt6LpLoiJR9Rqa?dl=0).
+Download the VirtualBox image [here](https://drive.google.com/file/d/1_a6q_9ggtrBtlA7Fghw5iYWkVrWlapDV/view?usp=sharing).
 
 ## Overview
 The goal of this workshop is to guide participants through the process of

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ See guide [here](docs/conference/conference.md) for workshop at a conference.
 
 ![](docs/workshop.png)
 
+Read through the [preparation document for this workshop](https://drive.google.com/file/d/1jWj1o_WbVGn6mk7BOqoVCJKciI6vymqw/view?usp=sharing).
+
 Download the VirtualBox image [here](https://drive.google.com/file/d/1_a6q_9ggtrBtlA7Fghw5iYWkVrWlapDV/view?usp=sharing).
 
 ## Overview


### PR DESCRIPTION
## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

Related to expired download link of virtual box image, https://github.com/open-rmf/rmf/discussions/257#discussioncomment-5016049.

Added link to prep document too.